### PR TITLE
Enable fallback to default Umbraco authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,4 @@ This version of UmbBackOfficeMembershipProvider can automatically create Umbraco
    - `<add key="BackOfficeMembershipProvider:AccountRoles" value="editor" />` - comma-separated list of groups user should be added to; defaults to **editor** if key is not present
    - `<add key="BackOfficeMembershipProvider:AccountCulture" value="en-US" />` - culture/language to use in creating new account; defaults to value of `umbracoDefaultUILanguage` if key is not present
    - `<add key="BackOfficeMembershipProvider:AccountEmailDomain" value="mydomain.com" />` - specifies domain name to be used in setting *username@accountemaildomain* e-mail address for newly created accounts; ignored if username is already a valid e-mail address, hostname of website is used otherwise if key is not present
+   - `<add key="BackOfficeMembershipProvider:FallbackToDefaultChecker" value="true" />` - set to `true` to enable fallback to default Umbraco authentication

--- a/src/UmbBackofficeMembershipProvider/BackofficeMembershipProviderPasswordChecker.cs
+++ b/src/UmbBackofficeMembershipProvider/BackofficeMembershipProviderPasswordChecker.cs
@@ -78,6 +78,20 @@ namespace UmbBackofficeMembershipProvider
         }
 
         /// <summary>
+        /// Determine if default Umbraco password checker should be used when user was not authenticated in Active Directory.
+        /// </summary>
+        public virtual bool FallbackToDefaultChecker
+        {
+            get
+            {
+                bool fallbackToDefaultChecker = false;
+                Boolean.TryParse(ConfigurationManager.AppSettings["BackOfficeMembershipProvider:FallbackToDefaultChecker"], out fallbackToDefaultChecker);
+
+                return fallbackToDefaultChecker;
+            }
+        }
+
+        /// <summary>
         /// Returns a ServiceContext
         /// </summary>
         public ServiceContext Services
@@ -206,7 +220,8 @@ namespace UmbBackofficeMembershipProvider
                 var userResult = await CreateUserForLogin(user);
             }
 
-            return validPassword ? BackOfficeUserPasswordCheckerResult.ValidCredentials : BackOfficeUserPasswordCheckerResult.InvalidCredentials;
+            return validPassword ? BackOfficeUserPasswordCheckerResult.ValidCredentials :
+                FallbackToDefaultChecker ? BackOfficeUserPasswordCheckerResult.FallbackToDefaultChecker : BackOfficeUserPasswordCheckerResult.InvalidCredentials;
         }
     }
 }


### PR DESCRIPTION
Allows for working in "mixed mode" - using both Active Directory and local users in Umbraco.